### PR TITLE
chore: rename org from Wuji-Technology-Co-Ltd to wuji-technology

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Debian 包提供系统级安装，适合需要集成到系统菜单的用户。�
 
 #### 下载
 下载最新对应版本的 .deb 文件：
-- GitHub Releases：https://github.com/Wuji-Technology-Co-Ltd/wujihand-upgrader-hmi/releases
+- GitHub Releases：https://github.com/wuji-technology/wujihand-upgrader-hmi/releases
 
 #### 安装步骤
 


### PR DESCRIPTION
将所有 GitHub 组织名引用从 `Wuji-Technology-Co-Ltd` 更新为 `wuji-technology`。