### PR TITLE
docs: add link to documentation center in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Wuji Hand Upgrader: firmware upgrade tool for Wuji Hand.
   - [Prerequisites](#prerequisites)
   - [Installation](#installation)
   - [Running](#running)
+- [Documentation](#documentation)
 - [Contact](#contact)
 
 ## Usage
@@ -70,6 +71,10 @@ Firmware upgrade requires the following sequence:
 4. Proceed with firmware upgrade
 
 **Note**: If the application shows "not in bootloader mode", power cycle the hand and retry.
+
+## Documentation
+
+For the full user guide, troubleshooting, and more, visit the [Wuji Documentation Center](https://docs.wuji.tech).
 
 ## Contact
 


### PR DESCRIPTION
## Summary

- 在 README 中新增 Documentation 章节，添加指向文档中心的链接
- 更新 Table of Contents

## 背景

Troubleshooting 等详细文档已迁移至[文档中心](https://docs.wuji.tech)（见 wuji-technology/wuji-docs-center#69），README 保持精简，通过链接引导用户前往完整文档。

Related: wuji-technology/wujihand-upgrader#14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 文档
- 新增文档导航入口：添加了官方文档中心的快速访问链接，用户可更便捷地获取完整的产品指南、使用教程和技术文档，提升文档的可发现性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->