### PR TITLE
docs: add Docs Center link and switch to Quick Start template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,38 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.1] - 2026-02-02
 
-### Improved
+### Added
 
-- Improved upgrade reliability with updated core components
+- Add GitHub Actions CI/CD workflow for automated build and release
+
+### Changed
+
+- Upgrade wujihand-upgrader-core dependency to v1.1.1
 
 ## [4.1.0] - 2026-01-12
 
 ### Added
 
-- Added post-upgrade guidance prompt on completion screen (close program, power cycle device)
+- Add post-upgrade guidance prompt on completion screen (close program, power cycle device)
 
 ### Fixed
 
-- Fixed release notes display on home page to show full content instead of collapsed view
+- Display full release notes on OTA home page instead of collapsed view
 
 ## [4.0.0] - 2025-12-31
 
 ### Added
 
-- Enhanced device connection logging
+- Enhance device connection logging
 
 ### Changed
 
-- Renamed application from wujihand-ota to wujihand-upgrader
-
-### Added
-
-- Added internationalization support for error messages
+- Rename binary from wujihand-ota to wujihand-upgrader
+- Rename organization from Wuji-Technology-Co-Ltd to wuji-technology
 
 ### Fixed
 
-- Fixed device update check issues
-- Fixed firmware version display
+- Fix device update check issues and React key warnings
+- Fix firmware version extraction logic
+- Replace hardcoded Chinese error messages with i18n internationalization
+- Comprehensive improvements to firmware version handling and error display
 
 [Unreleased]: https://github.com/wuji-technology/wujihand-upgrader/compare/v4.1.1...HEAD
 [4.1.1]: https://github.com/wuji-technology/wujihand-upgrader/compare/v4.1.0...v4.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,41 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.1] - 2026-02-02
 
-### Added
+### Improved
 
-- Add GitHub Actions CI/CD workflow for automated build and release
-
-### Changed
-
-- Upgrade wujihand-upgrader-core dependency to v1.1.1
+- Improved upgrade reliability with updated core components
 
 ## [4.1.0] - 2026-01-12
 
 ### Added
 
-- Add post-upgrade guidance prompt on completion screen (close program, power cycle device)
+- Added post-upgrade guidance prompt on completion screen (close program, power cycle device)
 
 ### Fixed
 
-- Display full release notes on OTA home page instead of collapsed view
+- Fixed release notes display on home page to show full content instead of collapsed view
 
 ## [4.0.0] - 2025-12-31
 
 ### Added
 
-- Enhance device connection logging
+- Enhanced device connection logging
 
 ### Changed
 
-- Rename binary from wujihand-ota to wujihand-upgrader
-- Rename organization from Wuji-Technology-Co-Ltd to wuji-technology
+- Renamed application from wujihand-ota to wujihand-upgrader
+
+### Added
+
+- Added internationalization support for error messages
 
 ### Fixed
 
-- Fix device update check issues and React key warnings
-- Fix firmware version extraction logic
-- Replace hardcoded Chinese error messages with i18n internationalization
-- Comprehensive improvements to firmware version handling and error display
+- Fixed device update check issues
+- Fixed firmware version display
 
 [Unreleased]: https://github.com/wuji-technology/wujihand-upgrader/compare/v4.1.1...HEAD
 [4.1.1]: https://github.com/wuji-technology/wujihand-upgrader/compare/v4.1.0...v4.1.1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/wuji-technology/wujihand-upgrader)](https://github.com/wuji-technology/wujihand-upgrader/releases)
 
-Wuji Hand Upgrader is the official firmware upgrade tool for Wuji Hand. It provides a guided workflow to flash firmware over USB with automatic bootloader detection.
+Wuji Hand Upgrader is the official firmware upgrade tool for Wuji Hand. It provides a guided workflow to flash firmware over USB with automatic bootloader detection. Available as a Debian package with one-click desktop launch.
 
 **Get started with [Quick Start](#quick-start). For detailed documentation, refer to [Wuji Hand Upgrader User Guide](https://docs.wuji.tech/docs/en/wuji-hand/latest/wuji-hand-upgrader-user-guide/) on Wuji Docs Center.**
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/wuji-technology/wujihand-upgrader)](https://github.com/wuji-technology/wujihand-upgrader/releases)
 
-Wuji Hand Upgrader: firmware upgrade tool for Wuji Hand.
+Wuji Hand Upgrader is the official firmware upgrade tool for Wuji Hand. It provides a guided workflow to flash firmware over USB with automatic bootloader detection.
 
-## Table of Contents
+**Get started with [Quick Start](#quick-start). For detailed documentation, refer to [Wuji Hand Upgrader User Guide](https://docs.wuji.tech/docs/en/wuji-hand/latest/wuji-hand-upgrader-user-guide/) on Wuji Docs Center.**
 
-- [Usage](#usage)
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
-  - [Running](#running)
-- [Contact](#contact)
-
-## Usage
+## Quick Start
 
 ### Prerequisites
 
@@ -22,36 +16,10 @@ Wuji Hand Upgrader: firmware upgrade tool for Wuji Hand.
 
 ### Installation
 
-#### Debian Package (.deb)
-
-Debian packages provide system-level installation with automatic permission configuration.
-
-#### Download
-
-Download the latest .deb package:
-- GitHub Releases: [https://github.com/wuji-technology/wujihand-upgrader/releases](https://github.com/wuji-technology/wujihand-upgrader/releases)
-
-#### Install
-
-Install the application using apt. Replace `<downloaded-package-name>` with the actual package name.
+Download the latest `.deb` package from [GitHub Releases](https://github.com/wuji-technology/wujihand-upgrader/releases), then install:
 
 ```bash
-sudo apt install ./<downloaded-package-name>.deb
-# If dependency issues occur
-sudo apt-get install -f
-```
-
-#### Permission Configuration
-
-After installation, the system will automatically:
-- Configure serial port access permissions
-- Add user to required groups
-- Set up hardware access permissions
-
-#### Uninstall
-
-```bash
-sudo apt remove wujihand-upgrader
+sudo apt install ./<package-name>.deb
 ```
 
 ### Running
@@ -59,17 +27,6 @@ sudo apt remove wujihand-upgrader
 Click the "WUJI" app icon on your desktop.
 
 **Note**: First run may take longer to extract and initialize the application.
-
-#### Upgrade Procedure
-
-Firmware upgrade requires the following sequence:
-
-1. Ensure the hand is **powered off**, then open Wuji Hand Upgrader application
-2. Connect the hand to PC via USB, then power on the hand
-3. The application will auto-connect to the bootloader
-4. Proceed with firmware upgrade
-
-**Note**: If the application shows "not in bootloader mode", power cycle the hand and retry.
 
 ## Contact
 


### PR DESCRIPTION
## Summary

- Expand summary to 3 sentences
- Add Docs Center link for Wuji Hand Upgrader User Guide
- Replace Usage with Quick Start template (repo is on Docs Center)
- Remove Table of Contents (not required for Docs Center repos)
- Fix CHANGELOG verb tense and remove internal implementation details
- Use mailto link format in Contact section
- Align install command placeholder with Docs Center formatting

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify Docs Center link resolves to the correct page
- [ ] Verify CHANGELOG comparison links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档更新**
  * 更新 README 引导，明确标示 Wuji Hand Upgrader 为官方固件升级工具，强调引导式 USB 刷写流程与自动引导加载器检测。
  * 精简安装与运行说明：移除冗长安装/卸载与权限配置步骤，统一建议使用 sudo apt install ./<package-name>.deb 进行安装。
  * 在文档顶部显著指向 Wuji Docs Center 获取完整用户指南与故障排查信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->